### PR TITLE
updated vite.config with dynamicImport plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 		"svelte-check": "^3.0.1",
 		"tslib": "^2.4.1",
 		"typescript": "^5.0.0",
-		"vite": "^4.2.0"
+		"vite": "^4.2.0",
+		"vite-plugin-dynamic-import": "^1.5.0"
 	},
 	"dependencies": {
 		"@fontsource/jetbrains-mono": "^4.5.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@fontsource/jetbrains-mono':
@@ -72,6 +76,9 @@ devDependencies:
   vite:
     specifier: ^4.2.0
     version: 4.2.0
+  vite-plugin-dynamic-import:
+    specifier: ^1.5.0
+    version: 1.5.0
 
 packages:
 
@@ -1089,6 +1096,10 @@ packages:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
     dev: true
 
+  /es-module-lexer@1.3.0:
+    resolution: {integrity: sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==}
+    dev: true
+
   /es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
     dev: true
@@ -1680,6 +1691,13 @@ packages:
 
   /magic-string@0.30.0:
     resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /magic-string@0.30.2:
+    resolution: {integrity: sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -2489,6 +2507,15 @@ packages:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
     dev: false
+
+  /vite-plugin-dynamic-import@1.5.0:
+    resolution: {integrity: sha512-Qp85c+AVJmLa8MLni74U4BDiWpUeFNx7NJqbGZyR2XJOU7mgW0cb7nwlAMucFyM4arEd92Nfxp4j44xPi6Fu7g==}
+    dependencies:
+      acorn: 8.8.2
+      es-module-lexer: 1.3.0
+      fast-glob: 3.2.12
+      magic-string: 0.30.2
+    dev: true
 
   /vite@4.2.0:
     resolution: {integrity: sha512-AbDTyzzwuKoRtMIRLGNxhLRuv1FpRgdIw+1y6AQG73Q5+vtecmvzKo/yk8X/vrHDpETRTx01ABijqUHIzBXi0g==}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
 import { sveltekit } from '@sveltejs/kit/vite'
+import dynamicImport from 'vite-plugin-dynamic-import'
 
 const config = {
-	plugins: [sveltekit()]
+	plugins: [sveltekit(), dynamicImport()]
 }
 
 export default config


### PR DESCRIPTION
My Blog wasn't running, pages showed 404 error. In order to fix the issue you have to do the following:
`npm i vite-plugin-dynamic-import -D`

Then in your vite.config add the plugin like so:

```
import { sveltekit } from '@sveltejs/kit/vite'
import dynamicImport from 'vite-plugin-dynamic-import'

const config = {
	plugins: [sveltekit(), dynamicImport()]
}

export default config
```